### PR TITLE
Fix for incorrect Regexp syntax.

### DIFF
--- a/lib/rcon.rb
+++ b/lib/rcon.rb
@@ -248,8 +248,9 @@ class RCon::Query::Original < RCon::Query
 
     @socket.print "\xFF" * 4 + "rcon #{@challenge_id} \"#{@password}\" #{@request}\n\x00"
     @response = retrieve_socket_data
+    @response.force_encoding('binary')
 
-    @response.sub! %/^\xFF\xFF\xFF\xFF#{@server_type}/, ""
+    @response.sub! /^\xFF\xFF\xFF\xFF#{@server_type}/n, ""
     @response.sub! /\x00+$/, ""
     
     return @response


### PR DESCRIPTION
This patch changes the `%//` string back into a regex (now with the `/n` modifier to force ASCII), and forces the response into binary encoding to allow for arbitrary bytes to be replaced in the regexp.  This is what's required for Ruby 2.0+